### PR TITLE
Add OOPI - Open Out-of-Pocket Pricing Index to Health Systems and Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A curated list of awesome healthcare datasets for machine learning, research, an
 7.  [Optum Clinformatics Data Mart](https://www.optum.com/business/life-sciences/real-world-data.html) - Commercial claims and EMR data. (Requires purchase, academic subscriptions available).
 8. [National Inpatient Sample (NIS)](https://www.hcup-us.ahrq.gov/nisoverview.jsp) - Largest all-payer inpatient care database in the US. (Available for purchase.)
 9. [National Ambulatory Medical Care Survey (NAMCS) and National Hospital Ambulatory Medical Care Survey (NHAMCS)](https://www.cdc.gov/nchs/ahcd/index.htm)- Provides data on ambulatory care visits.
+10. [OOPI - Open Out-of-Pocket Pricing Index](https://www.rxpricetracker.com/data) - Monthly cross-source US cash drug prices across CVS, GoodRx, Costco, Cost Plus Drugs, Amazon Pharmacy, SingleCare. 109 molecules. CC-BY-4.0. Mirrors: [HuggingFace](https://huggingface.co/datasets/pharmax-ai/oopi-pricing-index), [Zenodo DOI 10.5281/zenodo.20969232](https://zenodo.org/record/20969232), [Kaggle](https://www.kaggle.com/datasets/zackkmichael/oopi-us-cash-drug-prices).
 
 ## Biomedical Literature
 


### PR DESCRIPTION
Adds OOPI as item #10 in the Health Systems and Policy section, after NAMCS.

**What**: Monthly cross-source US cash drug prices for 109 molecules across CVS, GoodRx, Costco, Cost Plus Drugs, Amazon Pharmacy, SingleCare. Includes capture URLs and dates per observation.

**License**: CC-BY-4.0 (publicly downloadable, no purchase required)

**Mirrors**:
- HuggingFace: https://huggingface.co/datasets/pharmax-ai/oopi-pricing-index
- Zenodo (DOI 10.5281/zenodo.20969232): https://zenodo.org/record/20969232
- Kaggle: https://www.kaggle.com/datasets/zackkmichael/oopi-us-cash-drug-prices

Most of the section's existing entries are restricted/paid sources. OOPI fills the open-data gap for drug pricing.