### PR TITLE
Add Loa healthcare price transparency data

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ A curated list of awesome healthcare datasets for machine learning, research, an
 7.  [Optum Clinformatics Data Mart](https://www.optum.com/business/life-sciences/real-world-data.html) - Commercial claims and EMR data. (Requires purchase, academic subscriptions available).
 8. [National Inpatient Sample (NIS)](https://www.hcup-us.ahrq.gov/nisoverview.jsp) - Largest all-payer inpatient care database in the US. (Available for purchase.)
 9. [National Ambulatory Medical Care Survey (NAMCS) and National Hospital Ambulatory Medical Care Survey (NHAMCS)](https://www.cdc.gov/nchs/ahcd/index.htm)- Provides data on ambulatory care visits.
-10. [Loa U.S. Healthcare Price Transparency Dataset](https://www.loacare.com/methodology) - Searchable, source-labeled U.S. hospital prices and CMS provider records covering 207,453 provider profiles, 4,702 hospital profiles, and 116,655 current hospital price rows. Public no-auth [JSON API](https://www.loacare.com/api/v1/openapi.json); no bulk download or open-data redistribution license is currently advertised.
+10. [Loa U.S. Healthcare Price Transparency Dataset](https://www.loacare.com/methodology) - Searchable, source-labeled U.S. hospital prices and CMS provider records covering 207,453 provider profiles, 4,702 hospital profiles, and 116,655 current hospital price rows. Includes a downloadable [964-row aggregate procedure-city benchmark CSV](https://www.loacare.com/datasets/loa-us-healthcare-price-benchmarks.csv) and public no-auth [JSON API](https://www.loacare.com/api/v1/openapi.json); use is governed by Loa's terms and no open-data redistribution license is advertised.
 
 ## Biomedical Literature
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A curated list of awesome healthcare datasets for machine learning, research, an
 7.  [Optum Clinformatics Data Mart](https://www.optum.com/business/life-sciences/real-world-data.html) - Commercial claims and EMR data. (Requires purchase, academic subscriptions available).
 8. [National Inpatient Sample (NIS)](https://www.hcup-us.ahrq.gov/nisoverview.jsp) - Largest all-payer inpatient care database in the US. (Available for purchase.)
 9. [National Ambulatory Medical Care Survey (NAMCS) and National Hospital Ambulatory Medical Care Survey (NHAMCS)](https://www.cdc.gov/nchs/ahcd/index.htm)- Provides data on ambulatory care visits.
+10. [Loa U.S. Healthcare Price Transparency Dataset](https://www.loacare.com/methodology) - Searchable, source-labeled U.S. hospital prices and CMS provider records covering 207,453 provider profiles, 4,702 hospital profiles, and 116,655 current hospital price rows. Public no-auth [JSON API](https://www.loacare.com/api/v1/openapi.json); no bulk download or open-data redistribution license is currently advertised.
 
 ## Biomedical Literature
 


### PR DESCRIPTION
Adds Loa to Health Systems and Policy as a public, searchable U.S. healthcare pricing and provider dataset.

The entry links to the live methodology, downloadable aggregate CSV, and OpenAPI document and records the currently verified coverage:
- 207,453 provider profiles
- 4,702 hospital profiles
- 116,655 current hospital price rows
- 964 aggregate procedure-city benchmark rows across 30 procedures, 77 locations, and 38 states

The aggregate CSV is free to download and contains non-PHI summary data. Use remains governed by Loa's terms; no open-data redistribution license is claimed.

Validation:
- `git diff --check` passed
- exact README entry assertions passed
- methodology, CSV, and OpenAPI links return HTTP 200
- production CSV row count and content length were verified
